### PR TITLE
Added os_rng feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
 language: rust
 rust:
-    - nightly
-    - stable
+- nightly
+- stable
+
+env:
+- FEATURE=std
+- FEATURE=os_rng
+- FEATURE=cortex_m
+
+script:
+- cargo build --no-default-features --features=$FEATURE
+- cargo test --no-default-features --features=$FEATURE

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ license = "MIT"
 
 
 [features]
-std = [ "rand/std" ] 
+os_rng = [ "rand/std" ]
+std = [ "rand/std" ]
 cortex_m = [ "cortex-m", "lazy_static/spin_no_std" ]
 
-default = [ "std" ]
+default = [ "os_rng" ]
 
 [dependencies]
 rand = { version = "0.7.3", default_features = false }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
 # rand-facade
 
-An experimental global facade for `rand::RngCore` to support use of initialised random number generators in `no_std` capable libraries.
+An experimental global facade for `rand::RngCore` to support use of initialised random number generators in `no_std` capable libraries and projects, without needing to specify a given random generator within the library.
 
+This allows you to initialise and maintain a physical Random Number Generator (RNG) on `no_std` platforms, while allowing the sharing a global RNG (if required) or falling through to the default `OsRng` on `std` platforms.
+
+This is intended to be used as a dependency for relevant libraries / projects that require RNGs, and allows modes to be swapped using the feature flags described below.
+
+
+## Usage
+
+Include by adding `rand-facade = "0.1.0"` to your `Cargo.toml`.
+
+### Features
+
+- `os_rng` disables binding and falls through to the default `rand::rng::OsRng`, this is a sensible default for most apps
+- `std` enables global `Rng` binding using `std::sync::Mutex`
+- `cortex_m` enables global `Rng` binding using `cortex_m::Mutex`
 
 ## Status
 
@@ -13,4 +27,3 @@ This is a work in progress! Currently this works with `std` and `cortex-m` platf
 [![Docs.rs](https://docs.rs/rand-facade/badge.svg)](https://docs.rs/rand-facade)
 
 [Open Issues](https://github.com/ryankurte/rust-rand-facade/issues)
-


### PR DESCRIPTION
This bypasses (and removes access to) global binding and uses the `OsRng` implementation in the `GlobalRng` type.

Also added tests for each of the (mutually exclusive) features.